### PR TITLE
Fix pdflatex em dash garbled

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -12,6 +12,7 @@
 \usepackage{etoolbox}  % for showidx
 \usepackage{fullpage}
 \usepackage{soul}
+\usepackage[utf8]{inputenc}
 
 \usepackage{hyperref}  % should be last
 


### PR DESCRIPTION
OS: Ubuntu 18.04
pdflatex: pdfTeX 3.14159265-2.6-1.40.18 (TeX Live 2017/Debian)
pdflatex produces garbled characters when processing em dash.