### PR TITLE
Adding order-only prerequisite for parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,10 @@ $(T)/%.tex: %.tex | src
 src:
 	if [ ! -d $(SRC) ]; then \
 		git clone git@github.com:mit-pdos/xv6-riscv.git $(SRC) ; \
+	else \
+		git -C $(SRC) pull ; \
 	fi; \
-	cd $(SRC); git pull; true
+	true
 
 book.pdf: src book.tex $(TEX)
 	pdflatex book.tex

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ TEX=\
 	$(T)/sum.tex\
 
 all: book.pdf
-.PHONY: all
+.PHONY: all src clean
 
-$(T)/%.tex: %.tex
+$(T)/%.tex: %.tex | src
 	mkdir -p latex.out
 	./lineref $(notdir $@) $(SRC) > $@
 


### PR DESCRIPTION
Adding order-only requisite for src/ for parallel builds

Without this, make is allowed to execute pdflatex commands and the git clone/pull concurrently (or in the wrong order).
This is especially prone to happen when building with `-jN` N>1.

Also marking the other `PHONY` targets.