### PR TITLE
Adding a missing subphrase to the fs section

### DIFF
--- a/fs.tex
+++ b/fs.tex
@@ -1518,7 +1518,7 @@ makes a new device file.
 Like
 \indexcode{sys_link},
 \indexcode{create}
-starts by caling
+starts by calling
 \indexcode{nameiparent}
 to get the inode of the parent directory.
 It then calls

--- a/fs.tex
+++ b/fs.tex
@@ -973,11 +973,11 @@ This is a good on-disk representation but a
 complex one for clients.
 The function
 \indexcode{bmap}
-manages the representation so that higher-level routines such as
+manages the representation so that higher-level routines, such as
 \indexcode{readi}
 and
 \indexcode{writei},
-which we will see shortly.
+which we will see shortly, do not need to manage this complexity.
 \lstinline{Bmap}
 returns the disk block number of the
 \lstinline{bn}'th


### PR DESCRIPTION
Adding a missing clause to a sentence.

This can also be `s/so that/for/` in the original sentence.