### PR TITLE
Patch on texttt escape chracter error.

### DIFF
--- a/lock2.tex
+++ b/lock2.tex
@@ -94,8 +94,8 @@ count incremented, but not locked.
 Some data items are protected by different mechanisms at different
 times, and may at times be protected from concurrent access implicitly
 by the structure of the xv6 code rather than by explicit locks. For
-example, when a physical page is free, it is protected by \texttt{
-  kmem.lock} \lineref{kernel/kalloc.c:/^. kmem;/}. If the page is then
+example, when a physical page is free, it is protected by \texttt{kmem.lock}
+\lineref{kernel/kalloc.c:/^. kmem;/}. If the page is then
 allocated as a pipe \lineref{kernel/pipe.c:/^pipealloc/}, it is
 protected by a different lock (the embedded \lstinline{pi->lock}). If the page
 is re-allocated for a new process's user memory, it is not protected by a


### PR DESCRIPTION
    this is error message.

```
      Runaway argument?
    { protected by a different lock (the embedded \lstinline {pi->lock}).\ETC.
    ! File ended while scanning use of \texttt .
    <inserted text>
                    \par
    l.66 \input{latex.out/lock2}
```

    So, I fix the line like "{ .. } " in a line.