### PR TITLE
fix textt in interrupt.tex

### DIFF
--- a/interrupt.tex
+++ b/interrupt.tex
@@ -159,7 +159,7 @@ characters). This idea is sometimes called \indextext{I/O
 
 \section{Concurrency in drivers}
 
-You may have noticed calls to {\tt acquire} in {\texttt consoleread}
+You may have noticed calls to {\tt acquire} in \texttt{consoleread}
 and in {\tt consoleintr}. These calls acquire a lock, which protects
 the console driver's data structures from concurrent access.
 There are three concurrency dangers here: two processes on


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6597974/132763276-9e6e4b22-9238-4dd9-a36e-42d694dfa5f7.png)
Noticed `consoleread` formatted wrong while reading. I believe I'm fixing it correctly. 