### PR TITLE
remove duplicate code ref in sched.tex

### DIFF
--- a/sched.tex
+++ b/sched.tex
@@ -305,8 +305,6 @@ Thus, if one were to print out the line numbers where xv6 switches
 threads, one would observe the following simple pattern:
 \lineref{kernel/proc.c:/swtch..c/},
 \lineref{kernel/proc.c:/swtch..p/},
-\lineref{kernel/proc.c:/swtch..c/},
-\lineref{kernel/proc.c:/swtch..p/},
 and so on.
 Procedures that intentionally transfer control to each other via thread
 switch are sometimes referred to as


### PR DESCRIPTION
Hi, when reading xv6 book, I found there are duplicate in
 chapter7, the `swtch.c` and `swtch.p` are listed twice.
 So I changed them to list only one time.

I also sending email and patch to kaashoek,rtm@csail.mit.edu , but I'm not sure that should I send a patch or just edit the texts on github. So I do both of them.