### PR TITLE
Value of PHYSTOP, and potential typos

### DIFF
--- a/first.tex
+++ b/first.tex
@@ -577,7 +577,7 @@ it creates the first process by calling
 \lstinline{userinit}
 \lineref{kernel/proc.c:/^userinit/}.
 The first process executes a small program written in RISC-V assembly,
-make makes the first system call in xv6.
+makes the first system call in xv6.
 \indexcode{initcode.S} 
 \lineref{user/initcode.S:3} loads the number for the \lstinline{exec}
 system call, \lstinline{SYS_EXEC}

--- a/mem.tex
+++ b/mem.tex
@@ -199,7 +199,7 @@ declares the constants for xv6's kernel memory layout.
 
 QEMU simulates a computer that includes RAM (physical memory) starting
 at physical address \texttt{0x80000000} and continuing through
-at least \texttt{0x86400000}, which xv6 calls \texttt{PHYSTOP}.
+at least \texttt{0x88000000}, which xv6 calls \texttt{PHYSTOP}.
 The QEMU simulation also
 includes I/O devices
 such as a disk interface.

--- a/mem.tex
+++ b/mem.tex
@@ -73,7 +73,7 @@ room in the PTE format for the physical page number to grow by another
 technology predictions.  $2^{39}$ bytes is 512 GB, which should be
 enough address space for applications running on RISC-V
 computers. $2^{56}$ is enough physical memory space for the near
-future to fit may I/O devices and DRAM chips. If
+future to fit many I/O devices and DRAM chips. If
 more is needed, the RISC-V designers have defined Sv48 with 48-bit
 virtual addresses~\cite{riscv:priv}.
 

--- a/trap.tex
+++ b/trap.tex
@@ -46,7 +46,7 @@ commonality among the three trap types suggests that a kernel could
 handle all traps with a single code path, it turns out to be
 convenient to have separate code for
 three distinct cases: traps from user space, traps from kernel space,
-and timer interrupts. Kernel code (assembler or C) that
+and timer interrupts. Kernel code (assembly or C) that
 processes a trap is often called a \indextext{handler};
 the first handler instructions are usually written in assembler
 (rather than C) and are sometimes called a \indextext{vector}.


### PR DESCRIPTION
Dear Professor,

Given that PHYSTOP = KERNBASE + 128 * 1024 * 1024, should the value of PHYSTOP be 0x88000000L instead of 0x86400000L? If this is the case, Figure 3.3 on page 34 will require updates as well (value of PHYSTOP indicated as 0x86400000).

In addition, was wondering if the items below are typos.

Thank you!