### PR TITLE
Fixed a \lineref in sched.tex

### DIFF
--- a/sched.tex
+++ b/sched.tex
@@ -257,7 +257,7 @@ as though
 \indexcode{scheduler}'s
 \lstinline{swtch}
 had returned
-\lineref{kernel/proc.c:/swtch.*schedul.*contex/}.
+\lineref{kernel/proc.c:/swtch..c/}.
 The scheduler continues its
 \lstinline{for}
 loop, finds a process to run, 


### PR DESCRIPTION
A lineref here doesn't work. I changed the pattern to something I suspect to be the correct one.