### PR TITLE
Hide the boxes around the hyperlinks

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -14,7 +14,7 @@
 \usepackage{soul}
 \usepackage[utf8]{inputenc}
 
-\usepackage{hyperref}  % should be last
+\usepackage[hidelinks]{hyperref}  % should be last
 
 % One space after periods
 \frenchspacing


### PR DESCRIPTION
The red borders around all the links and references are not needed, so it is better to hide them.