### PR TITLE
Fix TEX variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SRC=xv6-riscv-src/
 
 T=latex.out
 
-TEX=$(wildcard $(T)/*.tex)
+TEX=$(foreach file, $(SPELLTEX), $(T)/$(file))
 SPELLTEX=$(wildcard *.tex)
 
 all: book.pdf


### PR DESCRIPTION
Previously make only worked after files in latex.out had already been created due to the wildcard used in TEX variable.