### PR TITLE
Rewording How Fork is Described

### DIFF
--- a/unix.tex
+++ b/unix.tex
@@ -167,8 +167,8 @@ A process may create a new process using the
 system call.
 \lstinline{fork}
 gives the new process an exact copy of the calling
-process's memory,
-both instructions and data.
+process's user-space memory,
+including instructions, data and stack.
 \lstinline{fork}
 returns in both the original and new processes.
 In the original process, \lstinline{fork} returns the new process's


### PR DESCRIPTION
The current text states that

> `fork` gives the new process an exact copy of the calling process's memory, both instruction and data. 

A few sentences above, the text states that

> An xv6 process consists of user-space memory (instructions, data, and stack) ...

The combination of these two sentences may imply that "stack" is not cloned during `fork`, and the code https://github.com/mit-pdos/xv6-riscv/blob/f5b93ef12f7159f74f80f94729ee4faabe42c360/kernel/proc.c#L292 implies that we are copying the whole user-space memory, including instructions, data, and stack. 

This PR rewords the sentence that describes fork to reduce ambiguity. 