### PR TITLE
Updated the return type specification.

### DIFF
--- a/unix.tex
+++ b/unix.tex
@@ -136,7 +136,7 @@ with each process.
 {\bf System call} & {\bf Description} \\
 \midrule
 int fork() & Create a process, return child's PID. \\
-int exit(int status) & Terminate the current process; status reported to wait(). No return. \\
+void exit(int status) & Terminate the current process; status reported to wait(). No return. \\
 int wait(int *status) & Wait for a child to exit; exit status in *status; returns child PID. \\
 int kill(int pid) & Terminate process PID. Returns 0, or -1 for error. \\
 int getpid() & Return the current process's PID. \\


### PR DESCRIPTION
Updated the return type of the `exit` syscall (int exit(int status)  --> void exit(int status)) in the first chapter.