### PR TITLE
Fix \includegraphics

### DIFF
--- a/mem.tex
+++ b/mem.tex
@@ -619,7 +619,7 @@ all address spaces, but can be used only by the kernel.
 
 \begin{figure}[t]
 \center
-\includegraphics[scale=0.5]{fig/processlayout.jpg}
+\includegraphics[scale=0.5]{fig/processlayout.png}
 \caption{A process's user address space, with its initial stack.}
 \label{fig:processlayout}
 \end{figure}


### PR DESCRIPTION
It tries to  include graphic fig/processlayout.jpg, but that file does not exist. Changed filename to fig/processlayout.png which exists. After that the book compiles fine