### PR TITLE
Fixed typo: 'progvhdr' to 'proghdr' in mem.tex.

### DIFF
--- a/aspell.words
+++ b/aspell.words
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 397 
+personal_ws-1.1 en 396 
 Abutalib
 acquiresleep
 addr
@@ -248,7 +248,6 @@ printf
 proc
 proc's
 proghdr
-progvhdr
 PTE
 PTEs
 pthread

--- a/mem.tex
+++ b/mem.tex
@@ -667,7 +667,7 @@ are formatted in the widely-used \indextext{ELF format}, defined in
 \indexcode{struct elfhdr} \lineref{kernel/elf.h:/^struct.elfhdr/},
 followed by a sequence of program section headers,
 \lstinline{struct proghdr} \lineref{kernel/elf.h:/^struct.proghdr/}.  Each
-\lstinline{progvhdr} describes a section of the application that must
+\lstinline{proghdr} describes a section of the application that must
 be loaded into memory; xv6 programs have two program section
 headers: one for instructions and one for data.
 


### PR DESCRIPTION
Also removed 'progvhdr' from aspell.words since
it's no longer needed after the fix.