### PR TITLE
Fix typo of bcache.lock

### DIFF
--- a/fs.tex
+++ b/fs.tex
@@ -243,7 +243,6 @@ disk sector, to ensure that readers see writes, and because the
 file system uses locks on buffers for synchronization.
 \lstinline{bget}
 ensures this invariant by holding the
-\lstinline{bache.lock}
 \lstinline{bcache.lock}
 continuously from the first loop's check of whether the
 block is cached through the second loop's declaration that


### PR DESCRIPTION
There was a previous commit that fixed the typo for `bache.lock`, but it forgot to remove the old line with the typo.