### PR TITLE
Remove extraneous slash from GitHub URLs

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -28,7 +28,7 @@
 \lstset{escapeinside={(*@}{@*)}}
 \lstset{xleftmargin=5.0ex}
 
-\newcommand{\github}{https://github.com/mit-pdos/xv6-riscv/blob/riscv/}
+\newcommand{\github}{https://github.com/mit-pdos/xv6-riscv/blob/riscv}
 
 \newcommand{\fileref}[1]{\small{\textcolor{red}{(#1)}}}
 \newcommand{\lineref}[2]{\small{\textcolor{red}{(#1:#2)}}}


### PR DESCRIPTION
Currently, the xv6 book contains GitHub URLs that look like this: `https://github.com/mit-pdos/xv6-riscv/blob/riscv//user/sh.c` (Note the extra `/` between `riscv` and `user`.)