### PR TITLE
Use `/usr/bin/env` for shebangs

### DIFF
--- a/bin/capital.py
+++ b/bin/capital.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/xv6-riscv-src-booklet/pr.pl
+++ b/xv6-riscv-src-booklet/pr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use POSIX qw(strftime);
 

--- a/xv6-riscv-src-booklet/runoff
+++ b/xv6-riscv-src-booklet/runoff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo This script takes a minute to run.  Be patient. 1>&2
 

--- a/xv6-riscv-src-booklet/runoff1
+++ b/xv6-riscv-src-booklet/runoff1
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $n = 0;
 $v = 0;


### PR DESCRIPTION
Hard-coded interpreter paths like `/usr/bin/perl` can cause build failures on systems like NixOS, but `/usr/bin/env` fixes these.