### PR TITLE
Typo: schedule -> scheduler

### DIFF
--- a/sched.tex
+++ b/sched.tex
@@ -19,7 +19,7 @@ and
 {\tt yield()},
 {\tt sched()},
 and
-{\tt schedule()}
+{\tt scheduler()}
 in {\tt kernel/proc.c}.
 
 %% 


### PR DESCRIPTION
There is no `schedule` function, I assume this is meant to refer to [`scheduler`](https://github.com/mit-pdos/xv6-riscv/blob/riscv/kernel/proc.c#L425)