### PR TITLE
Fix duplicated “calls” in Chapter 1

### DIFF
--- a/first.tex
+++ b/first.tex
@@ -186,7 +186,7 @@ the
 \indextext{kernel}.
 
 Applications interact with the kernel via system calls
-calls such as {\tt read}.
+such as {\tt read}.
 Applications are not allowed to directly call kernel functions
 or access the kernel's memory.
 RISC-V provides the \indexcode{ecall} instruction


### PR DESCRIPTION
This PR fixes a duplicated word in `first.tex`, in Chapter 1's description of how applications interact with the kernel through system calls.

Before:

`Applications interact with the kernel via system calls calls such as read.`

After:

`Applications interact with the kernel via system calls such as read.`

This change removes the duplicated `calls`.
